### PR TITLE
Corregida errata en el nombre del despliegue

### DIFF
--- a/Labs/Lab-2/README.md
+++ b/Labs/Lab-2/README.md
@@ -130,7 +130,7 @@ Requisitos:
 
   2.10. Añadir el ConfigMap a la configuracion del deployment:
 
-    $ oc set volume deploy/nginx --add --overwrite --name=config-volume -m /data/ -t configmap --configmap-name=nginx-config-file
+    $ oc set volume deploy/my-nginx --add --overwrite --name=config-volume -m /data/ -t configmap --configmap-name=nginx-config-file
 
   2.11. Encontrar el pod que este Running:
 
@@ -220,6 +220,3 @@ Requisitos:
 
        $ oc set volume deployment/my-nginx --remove --name=myvol
        $ oc delete pvc <nombre-pvc>
-
-
-


### PR DESCRIPTION
He corregido una errata en la documentación.

La siguiente línea:

    $ oc set volume deploy/nginx ...

Debería ser:

    $ oc set volume deploy/my-nginx ...